### PR TITLE
Linguist Override For TypeScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# github/linguist override
+*.ts linguist-language=Typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "create simple, opiniated typescript projects",
   "bin": {
     "create-typescript-project": "build/index.js",


### PR DESCRIPTION
https://github.com/github/linguist/blob/master/README.md#using-gitattributes
https://git-scm.com/docs/gitattributes

shebang ("#!/usr/bin/env node") seems to be the reason why the files were misclassified as JS.

https://github.com/github/linguist/issues/4558