### PR TITLE
Error: Command failed with exit code 2 (ENOENT): tsc --init --outDir build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "create simple, opiniated typescript projects",
   "bin": {
     "create-typescript-project": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-typescript-project",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "create simple, opiniated typescript projects",
   "bin": {
     "create-typescript-project": "build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ async function installTypescript(nodeVersion?: string): Promise<void> {
     "ts-node",
     "--save-dev"
   ]);
-  await execa("tsc", ["--init", "--outDir", "build"]);
+  await execa("npx", ["tsc", "--init", "--outDir", "build"]);
   process.stdout.write("Done" + EOL);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ async function installedManagedDependencies(
       : "create-typescript-project-dependencies",
     "--save-dev"
   ]);
-  await execa("tsc", ["--init", "--outDir", "build"]);
+  await execa("npx", ["tsc", "--init", "--outDir", "build"]);
   process.stdout.write("Done" + EOL);
 }
 


### PR DESCRIPTION
```bash
$ npm init typescript-project --managed
(node:27875) ExperimentalWarning: The fs.promises API is experimental
Bootstrapping package.json ... Done
Installing managed dependencies ... (node:27875) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 2 (ENOENT): tsc --init --outDir build
spawn tsc ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
    at onErrorNT (internal/child_process.js:415:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
(node:27875) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:27875) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```